### PR TITLE
Raise parser#failure_reason instead of mostly unhelpful 'failure at index {parser#index}'

### DIFF
--- a/parser.rb
+++ b/parser.rb
@@ -21,7 +21,7 @@ class Parser
     # If the AST is nil then there was an error during parsing
     # we need to report a simple error message to help the user
     if(tree.nil?)
-      raise Exception, "Parse error at offset: #{@@parser.index}"
+      raise Exception, @@parser.failure_reason
     end
     
     # Remove all syntax nodes that aren't one of our custom


### PR DESCRIPTION
In most all cases, parser#index is 0, even if it was able to successfully parse a fragment of the rule.
